### PR TITLE
feat: add notes input

### DIFF
--- a/src/components/TransactionForm/TransactionForm.test.tsx
+++ b/src/components/TransactionForm/TransactionForm.test.tsx
@@ -154,3 +154,18 @@ describe('Transaction Form -- Fee Input', () => {
     expect(screen.getByText(expectedLabel)).toBeInTheDocument();
   });
 });
+
+describe('Transaction Form -- Notes Input', () => {
+  // simple render test only -- anything more creeps into testing
+  // 3rd-party functionality
+  it('renders', () => {
+    const onChange = jest.fn();
+    const value = 'Bought on Coinbase';
+    const expectedLabel = 'Notes';
+
+    render(<TransactionForm.NotesInput onChange={onChange} value={value} />);
+
+    expect(screen.getByDisplayValue(value)).toBeInTheDocument();
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+});

--- a/src/components/TransactionForm/TransactionForm.tsx
+++ b/src/components/TransactionForm/TransactionForm.tsx
@@ -137,12 +137,34 @@ const FeeInput: FunctionComponent<FeeInputProps> = ({ onChange, value }) => {
   );
 };
 
+interface NotesInputProps {
+  onChange: (event: ChangeEvent<HTMLInputElement>) => {};
+  value: string;
+}
+
+const NotesInput: FunctionComponent<NotesInputProps> = ({
+  onChange,
+  value,
+}) => {
+  return (
+    <TextField
+      label="Notes"
+      value={value}
+      onChange={onChange}
+      name="notes"
+      id="notes"
+      multiline
+    />
+  );
+};
+
 const TransactionForm = {
   ExchangeSelect,
   TradingPairSelect,
   PricePerCoinInput,
   QuantityInput,
   FeeInput,
+  NotesInput,
 };
 
 export default TransactionForm;


### PR DESCRIPTION
Adds notes input component for transaction form. Allows user to specify any notes for a given transaction. Includes unit test to verify functionality