### PR TITLE
feat: retrieve exchange's trading pairs from API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4569,6 +4569,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -8628,6 +8637,16 @@
         "jest-util": "^26.6.2"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -10421,6 +10440,12 @@
           "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "node-forge": {
       "version": "0.10.0",
@@ -12239,6 +12264,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
+      "dev": true
     },
     "prompts": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.0",
+    "jest-fetch-mock": "3.0.3",
     "prettier": "2.3.1"
   }
 }

--- a/src/api/crypto.test.ts
+++ b/src/api/crypto.test.ts
@@ -1,0 +1,43 @@
+import crypto, { Errors } from './crypto';
+
+import fetchMock from 'jest-fetch-mock';
+
+describe('Crypto API -- get exchange trading pairs', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  it('retrieves coin trading pairs on a given exchange', async () => {
+    const mockData = [
+      { exchange: 'binance', market: 'BTCUSDT', base: 'BTC', quote: 'USD' },
+      { exchange: 'binance', market: 'BTCETH', base: 'BTC', quote: 'ETH' },
+    ];
+
+    fetchMock.mockResponseOnce(JSON.stringify(mockData));
+    const { getExchangeTradingPairs } = crypto;
+
+    const pairBase = 'BTC';
+    const exchangeId = 'binance';
+
+    const responseData = await getExchangeTradingPairs(pairBase, exchangeId);
+    expect(responseData).toEqual(mockData);
+  });
+
+  it('throws correct error on data retrieval error', async () => {
+    fetchMock.mockImplementationOnce(() => {
+      return new Promise(() => {
+        throw new Error('retrieval error');
+      });
+    });
+
+    const { getExchangeTradingPairs } = crypto;
+
+    const pairBase = 'BTC';
+    const exchangeId = 'binance';
+
+    const expectedError = new Error(Errors.TradingPairsRetrieval);
+    await expect(
+      getExchangeTradingPairs(pairBase, exchangeId)
+    ).rejects.toThrowError(expectedError);
+  });
+});

--- a/src/api/crypto.ts
+++ b/src/api/crypto.ts
@@ -1,0 +1,29 @@
+const API_BASE_URL = 'https://api.nomics.com/v1';
+const API_KEY = process.env.NOMICS_API_KEY;
+
+export enum Errors {
+  TradingPairsRetrieval = 'TradingPairsRetrieval',
+}
+
+/**
+ * Retrieves trading pairs for the given currency on the provided exchange
+ * @param pairBase - Currency to get trading pairs for
+ * @param exchangeId - Exchange to get trading pairs for the given pairBase
+ * @returns Trading pairs JSON
+ */
+const getExchangeTradingPairs = (pairBase: string, exchangeId: string) => {
+  const queryParams = `key=${API_KEY}&base=${pairBase}&exchange=${exchangeId}`;
+  const url = `${API_BASE_URL}/markets?${queryParams}`;
+
+  return fetch(url)
+    .then((response) => response.json())
+    .catch(() => {
+      throw new Error(Errors.TradingPairsRetrieval);
+    });
+};
+
+const crypto = {
+  getExchangeTradingPairs,
+};
+
+export default crypto;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+process.env.NOMICS_API_KEY = 'mock-api-key';
+
+require('jest-fetch-mock').enableMocks();


### PR DESCRIPTION
Adds function to retrieve a coin's trading pairs from a given exchange via Nomics API. Includes unit tests to verify functionality.