### PR TITLE
feat: hook to retrieve exchange pairs from API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,6 +2301,19 @@
         "@testing-library/dom": "^7.28.1"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.0.tgz",
+      "integrity": "sha512-WFBGH8DWdIGGBHt6PBtQPe2v4Kbj9vQ1sQ9qLBTmwn1PNggngint4MTE/IiWCYhPbyTW3oc/7X62DObMn/AjQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@testing-library/user-event": {
       "version": "12.8.3",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
@@ -2481,6 +2494,15 @@
       "version": "17.0.8",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.8.tgz",
       "integrity": "sha512-0ohAiJAx1DAUEcY9UopnfwCE9sSMDGnY/oXjWMax6g3RpzmTt2GMyMVAXcbn0mo8XAff0SbQJl2/SBU+hjSZ1A==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -12627,6 +12649,15 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
+      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/react-hooks": "7.0.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.0",
     "jest-fetch-mock": "3.0.3",

--- a/src/api/crypto.ts
+++ b/src/api/crypto.ts
@@ -1,3 +1,5 @@
+import { ExchangePair } from '../types';
+
 const API_BASE_URL = 'https://api.nomics.com/v1';
 const API_KEY = process.env.NOMICS_API_KEY;
 
@@ -11,18 +13,29 @@ export enum Errors {
  * @param exchangeId - Exchange to get trading pairs for the given pairBase
  * @returns Trading pairs JSON
  */
-const getExchangeTradingPairs = (pairBase: string, exchangeId: string) => {
+const getExchangeTradingPairs = (
+  pairBase: string,
+  exchangeId: string
+): Promise<ExchangePair[]> => {
   const queryParams = `key=${API_KEY}&base=${pairBase}&exchange=${exchangeId}`;
   const url = `${API_BASE_URL}/markets?${queryParams}`;
 
   return fetch(url)
     .then((response) => response.json())
+    .then((data) => data as ExchangePair[])
     .catch(() => {
       throw new Error(Errors.TradingPairsRetrieval);
     });
 };
 
-const crypto = {
+export interface CryptoApi {
+  getExchangeTradingPairs: (
+    pairBase: string,
+    exchangeId: string
+  ) => Promise<ExchangePair[]>;
+}
+
+const crypto: CryptoApi = {
   getExchangeTradingPairs,
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ enum TRANSACTION_TYPE {
 
 export interface Transaction {
   type: TRANSACTION_TYPE;
+  exchangeId: string;
   coin: string;
   pairTarget: string;
   pricePerCoin: number;
@@ -19,4 +20,11 @@ export interface Transaction {
   fee: number;
   date: Date;
   notes: string;
+}
+
+export interface ExchangePair {
+  exchange: string;
+  market: string;
+  base: string;
+  quote: string;
 }


### PR DESCRIPTION
Adds a hook to support transaction form (and potentially other areas of the application) to retrieve exchange-specific trading pairs for a given coin. The hook's interface exposes a function that allows the consumer to set a new exchange to retrieve trading pairs for a given coin on demand.

Includes unit tests to verify functionality.