### PR TITLE
feat: retrieve exchange listings for coin

### DIFF
--- a/src/api/crypto.ts
+++ b/src/api/crypto.ts
@@ -1,10 +1,12 @@
-import { ExchangePair } from '../types';
+import { ExchangePair, Exchange } from '../types';
+import { SUPPORTED_EXCHANGES } from '../constants';
 
 const API_BASE_URL = 'https://api.nomics.com/v1';
 const API_KEY = process.env.NOMICS_API_KEY;
 
 export enum Errors {
   TradingPairsRetrieval = 'TradingPairsRetrieval',
+  ExchangeListingsRetrieval = 'ExchangeListingsRetrieval',
 }
 
 /**
@@ -28,15 +30,54 @@ const getExchangeTradingPairs = (
     });
 };
 
+/**
+ * Retrieves a coin's exchange listings by retrieving all exchange
+ * pairs for a given coin & merging with array of supported exchanges
+ * @param pairBase - Currency to get trading pairs for
+ * @returns Array of supported exchanges that list the coin
+ */
+const getExchangeListings = (pairBase: string): Promise<Exchange[]> => {
+  const queryParams = `key=${API_KEY}&base=${pairBase}`;
+  const url = `${API_BASE_URL}/markets?${queryParams}`;
+
+  return fetch(url)
+    .then((response) => response.json())
+    .then((data) => data as ExchangePair[])
+    .then((exchangePairs) => {
+      const exchangesListingCoinLookup: { [exchangeId: string]: boolean } =
+        exchangePairs.reduce((accumulator, exchangePair) => {
+          return {
+            ...accumulator,
+            [exchangePair.exchange]: true,
+          };
+        }, {});
+
+      return exchangesListingCoinLookup;
+    })
+    .then((exchangesListingCoinLookup) => {
+      return SUPPORTED_EXCHANGES.filter((supportedExchange) => {
+        const isListedOnSupportedExchange =
+          exchangesListingCoinLookup[supportedExchange.id];
+
+        return isListedOnSupportedExchange;
+      });
+    })
+    .catch(() => {
+      throw new Error(Errors.ExchangeListingsRetrieval);
+    });
+};
+
 export interface CryptoApi {
   getExchangeTradingPairs: (
     pairBase: string,
     exchangeId: string
   ) => Promise<ExchangePair[]>;
+  getExchangeListings: (pairBase: string) => Promise<Exchange[]>;
 }
 
 const crypto: CryptoApi = {
   getExchangeTradingPairs,
+  getExchangeListings,
 };
 
 export default crypto;

--- a/src/components/TransactionForm/TransactionForm.test.tsx
+++ b/src/components/TransactionForm/TransactionForm.test.tsx
@@ -198,6 +198,7 @@ describe('useExchangePairs', () => {
     };
     const mockCryptoApi: CryptoApi = {
       getExchangeTradingPairs: mockGetExchangeTradingPairs,
+      getExchangeListings: () => Promise.resolve([]),
     };
 
     const { result, waitForNextUpdate } = renderHook(() =>
@@ -226,6 +227,7 @@ describe('useExchangePairs', () => {
 
     const mockCryptoApi: CryptoApi = {
       getExchangeTradingPairs: mockGetExchangeTradingPairs,
+      getExchangeListings: () => Promise.resolve([]),
     };
 
     const { result, waitForNextUpdate } = renderHook(() =>
@@ -262,6 +264,7 @@ describe('useExchangePairs', () => {
 
     const mockCryptoApi: CryptoApi = {
       getExchangeTradingPairs: mockGetExchangeTradingPairs,
+      getExchangeListings: () => Promise.resolve([]),
     };
 
     const { result, waitForNextUpdate } = renderHook(() =>


### PR DESCRIPTION
Adds network request function to retrieve exchanges that list a given coin. Will be used to populate options for exchange select component in transaction form. Includes unit tests to verify functionality.